### PR TITLE
Remove SYNC_SETTINGS permission

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,6 +8,7 @@ android {
     compileSdk 34
 
     defaultConfig {
+        minSdk 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -6,17 +6,10 @@
         <package android:name="ee.oyatl.ime.f.ko" />
     </queries>
 
-    <permission
-        android:name="ee.oyatl.ime.f.permission.SYNC_SETTINGS"
-        android:label="@string/permission_sync_settings_label"
-        android:description="@string/permission_sync_settings_description"
-        android:protectionLevel="normal" />
-
     <application>
         <receiver
             android:name=".SettingsBroadcastReceiver"
-            android:exported="true"
-            android:permission="ee.oyatl.ime.f.permission.SYNC_SETTINGS">
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="ee.oyatl.ime.f.intent.action.SYNC_SETTINGS" />

--- a/common/src/main/res/xml/file_paths.xml
+++ b/common/src/main/res/xml/file_paths.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <files-path name="default_prefs" path="shared_prefs/default.xml" />
-</paths>

--- a/ime-en/src/main/AndroidManifest.xml
+++ b/ime-en/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="ee.oyatl.ime.f.permission.SYNC_SETTINGS" />
 
     <application
         android:name=".FboardAppEnglish"

--- a/ime-ko/src/main/AndroidManifest.xml
+++ b/ime-ko/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.VIBRATE" />
-    <uses-permission android:name="ee.oyatl.ime.f.permission.SYNC_SETTINGS" />
 
     <application
         android:name=".FboardAppKorean"


### PR DESCRIPTION
It seems like by declaring the permission in common module it is inherited to each apps, resulting not being able to install more than one app with it.